### PR TITLE
URI Path component was being improperly encoded

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,16 +1,42 @@
+#!/usr/bin/env python
+
 import requests
+
 from awsauth import S3Auth
 
-ACCESS_KEY = 'ACCESSKEYXXXXXXXXXXXX'
-SECRET_KEY = 'AWSSECRETKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'        
+import StringIO
 
-# Creating a file
-r = requests.put('http://mybucket.s3.amazonaws.com/myfile.txt', data='Sam is sweet', auth=S3Auth(ACCESS_KEY, SECRET_KEY))
+import gzip
 
-# Downloading a file
-r = requests.get('http://mybucket.s3.amazonaws.com/myfile.txt', auth=S3Auth(ACCESS_KEY, SECRET_KEY))
-if r.content == 'Sam is sweet':
-    print 'Hala Madrid!'
+import urllib
 
-# Removing a file
-r = requests.delete('http://mybucket.s3.amazonaws.com/myfile.txt', auth=S3Auth(ACCESS_KEY, SECRET_KEY))
+ACCESS_KEY = "ACCESSKEYXXXXXXXXXXXX"
+SECRET_KEY = "AWSSECRETKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+acceptableAccessCodes = (200, 204) # # https://forums.aws.amazon.com/thread.jspa?threadID=28799: http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTObjectDELETE.html
+
+if __name__ == '__main__':
+
+    confirmIt = u'Sam is sweet' # Data needs to be in unicode, or it will fail
+
+    bucketName = 'mybucket'
+    objectName = ['myfile.txt', 'my+file.txt']
+
+    for o in objectName:
+        # Creating a file
+        r = requests.put(('http://%s.s3.amazonaws.com/%s' % (bucketName, o)), data=confirmIt, auth=S3Auth(ACCESS_KEY, SECRET_KEY))
+        if r.status_code not in acceptableAccessCodes:
+            r.raise_for_status()
+
+        # Downloading a file
+        r = requests.get(('http://%s.s3.amazonaws.com/%s' % (bucketName, o)), auth=S3Auth(ACCESS_KEY, SECRET_KEY))
+        if r.status_code not in acceptableAccessCodes:
+            r.raise_for_status()
+
+        if r.content == confirmIt:
+            print 'Hala Madrid!'
+
+        # Removing a file
+        r = requests.delete(('http://%s.s3.amazonaws.com/%s' % (bucketName, o)), auth=S3Auth(ACCESS_KEY, SECRET_KEY))
+        if r.status_code not in acceptableAccessCodes:
+            r.raise_for_status()


### PR DESCRIPTION
With my example.py on existing awsauth.py it crashes and burns on the second iteration that processes the filename with a '+' in it.

The awsauth.py I committed should fix it and possibly introduce yet more bugs.
