### PR TITLE
Added support for Python 3

### DIFF
--- a/awsauth.py
+++ b/awsauth.py
@@ -45,8 +45,6 @@ class S3Auth(AuthBase):
         if py3k:
             signature = signature.decode('utf-8')
         r.headers['Authorization'] = 'AWS %s:%s' % (self.access_key, signature)
-        from pprint import pprint
-        pprint(r.headers)
         return r
 
     def get_signature(self, r):


### PR DESCRIPTION
Added support for Python 3 while maintaining the Python 2 codebase. Validates against PEP8 :+1: 

Might be worth documenting the headers={'x-amz-acl': 'public-read'} option as well?
