### PR TITLE
Update of missing API query parameters

### DIFF
--- a/awsauth.py
+++ b/awsauth.py
@@ -29,7 +29,8 @@ class S3Auth(AuthBase):
         'torrent', 'versioning', 'versionId', 'versions', 'website', 'uploads',
         'uploadId', 'response-content-type', 'response-content-language',
         'response-expires', 'response-cache-control', 'delete', 'lifecycle',
-        'response-content-disposition', 'response-content-encoding'
+        'response-content-disposition', 'response-content-encoding', 'tagging',
+        'notification', 'cors'
     ]
 
     def __init__(self, access_key, secret_key, service_url=None):

--- a/test.py
+++ b/test.py
@@ -2,6 +2,8 @@ import unittest
 import os
 import requests
 from awsauth import S3Auth
+import hashlib
+import base64
 
 
 TEST_BUCKET = 'testpolpol'
@@ -55,6 +57,57 @@ class TestAWS(unittest.TestCase):
         # Removing a file
         r = requests.delete(url, auth=self.auth)
         self.assertEqual(r.status_code, 204)
+
+    def test_put_get_delete_cors(self):
+        url = 'http://'+ TEST_BUCKET + '.s3.amazonaws.com/?cors'
+        testdata = '<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">\
+                            <CORSRule>\
+                            <AllowedOrigin>*</AllowedOrigin>\
+                            <AllowedMethod>POST</AllowedMethod>\
+                            <MaxAgeSeconds>3000</MaxAgeSeconds>\
+                            <AllowedHeader>Authorization</AllowedHeader>\
+                        </CORSRule>\
+                    </CORSConfiguration>'
+        content_md5 = base64.encodestring(hashlib.md5(testdata.strip()).digest()).strip()
+        r = requests.put(url, data=testdata, auth=self.auth, headers={'content-md5': content_md5})
+        self.assertEqual(r.status_code, 200)
+        # Downloading current cors configuration
+        r = requests.get(url, auth=self.auth)
+        self.assertEqual(r.status_code, 200)
+        # Removing removing cors configuration
+        r = requests.delete(url, auth=self.auth)
+        self.assertEqual(r.status_code, 204)
+
+    def test_put_get_delete_tagging(self):
+        url = 'http://'+ TEST_BUCKET + '.s3.amazonaws.com/?tagging'
+        testdata = '<Tagging>\
+                        <TagSet>\
+                            <Tag>\
+                                <Key>Project</Key>\
+                                <Value>Project 1</Value>\
+                            </Tag>\
+                        </TagSet>\
+                    </Tagging>'
+        content_md5 = base64.encodestring(hashlib.md5(testdata.strip()).digest()).strip()
+        r = requests.put(url, data=testdata, auth=self.auth, headers={'content-md5': content_md5})
+        self.assertEqual(r.status_code, 204)
+        # Downloading current cors configuration
+        r = requests.get(url, auth=self.auth)
+        self.assertEqual(r.status_code, 200)
+        # Removing removing cors configuration
+        r = requests.delete(url, auth=self.auth)
+        self.assertEqual(r.status_code, 204)
+
+    def test_put_get_notification(self):
+        url = 'http://'+ TEST_BUCKET + '.s3.amazonaws.com/?notification'
+        testdata = '<NotificationConfiguration></NotificationConfiguration>'
+        content_md5 = base64.encodestring(hashlib.md5(testdata.strip()).digest()).strip()
+        r = requests.put(url, data=testdata, auth=self.auth, headers={'content-md5': content_md5})
+        self.assertEqual(r.status_code, 200)
+        # Downloading current cors configuration
+        r = requests.get(url, auth=self.auth)
+        self.assertEqual(r.status_code, 200)
+        # No Delete ?notification API, empty <NotificationConfiguration> tag is default
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added the missing parameters (tagging, cors, notification) that are required in Amazon's aws version 2 "string to sign". 